### PR TITLE
Make ada not crash a worker when accessed on a bad route

### DIFF
--- a/middleware/json_loader.py
+++ b/middleware/json_loader.py
@@ -7,7 +7,7 @@ class JsonLoader:
         self.logger = logger.with_class_name(self)
 
     def process_resource(self, req, res, resource, params):
-        if not resource.has_json_body:
+        if not getattr(resource, 'has_json_body', False):
             return
         try:
             req.context.body = json.loads(req.context.body)

--- a/middleware/logger.py
+++ b/middleware/logger.py
@@ -4,6 +4,6 @@ class LoggerMiddleware:
         self.logger = logger.with_class_name(self)
 
     def process_response(self, req, res, resource, req_succeded):
-        if resource.ignore_middleware_log:
+        if getattr(resource, 'ignore_middleware_log', False):
             return
         self.logger.log(f'{res.status} {req.method} {req.relative_uri}')


### PR DESCRIPTION
This solves issue [#13](https://github.com/IMEsec-USP/issues/issues/13). 

Basically, `process_resource` can have `None` as a resource.
The middlewares default to a happy path now.