### PR TITLE
Removes Lightning-hacks chat from Ada

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,5 @@
 from environs import Env
 
-CHAT_ID_LIGHTNING_HACKS = -1001342903759
 CHAT_ID_IMESEC_CORE     = -1001284501077
 CHAT_ID_RAZGRIZONE      = 131845033
 CHAT_ID_R0ZBOT          = 211525815
@@ -18,8 +17,7 @@ GITHUB_SECRET = env('GITHUB_SECRET')
 # Dict of conversations IDs followed by regex to match agains repository names
 default_conversations = {
     CHAT_ID_RAZGRIZONE: '.*',
-    CHAT_ID_LIGHTNING_HACKS: '^((?!dockerhub).)*lightning-hacks.*$',
-    CHAT_ID_IMESEC_CORE: '^((?!lightning-hacks).)*$',
+    CHAT_ID_IMESEC_CORE: '.*',
     CHAT_ID_R0ZBOT: '.*'
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7110169/94998999-06b67000-05ae-11eb-9b45-008f514b89dc.png)

### What does this code do?
Moves all lightning-hacks related PRs to alert on imesec-core instead of lightning-hacks chat.